### PR TITLE
Name of solution branch incorrect

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,4 +88,4 @@ This will make your `index.html` file available at the URL:
 
 `http://<username>.github.io/HelloCodeSchoolProject/`
 
-For instance, our `answer` branch is available at the url [http://codeschool.github.io/HelloCodeSchoolProject/](http://codeschool.github.io/HelloCodeSchoolProject/).
+For instance, our `solution` branch is available at the url [http://codeschool.github.io/HelloCodeSchoolProject/](http://codeschool.github.io/HelloCodeSchoolProject/).


### PR DESCRIPTION
Corrected the name of the `solution` branch in Readme.md from `answer` to `solution` to match actual branch name.